### PR TITLE
Fix reload of Home Screen

### DIFF
--- a/lib/service/notes_service.dart
+++ b/lib/service/notes_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:collection_ext/iterables.dart';
 import 'package:flutter/material.dart';
 import 'package:keep/model/note.dart';
+import 'package:keep/screen/home_screen.dart';
 
 import '../styles.dart';
 
@@ -97,6 +98,7 @@ mixin CommandHandler<T extends StatefulWidget> on State<T> {
         ),
       ));
     }
+    Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => HomeScreen()));
   }
 }
 

--- a/lib/service/notes_service.dart
+++ b/lib/service/notes_service.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:collection_ext/iterables.dart';
 import 'package:flutter/material.dart';
 import 'package:keep/model/note.dart';
+import 'package:keep/screen/home_screen.dart';
 
 import '../styles.dart';
 
@@ -97,6 +98,11 @@ mixin CommandHandler<T extends StatefulWidget> on State<T> {
         ),
       ));
     }
+    /* bug : The Navigator.pop don't refresh the home screen
+     fix: We add this line so that after every action, the user will be redirect to home screen
+     which will refresh the screen
+     */
+    Navigator.of(context).pushReplacement(MaterialPageRoute(builder: (context) => HomeScreen()));
   }
 }
 


### PR DESCRIPTION
Bug: During my test I found that every actions on the note like delete, archive redirect to the Home Screen without refreshing. So you can still see the same note you deleted.

Cause: It seems like the Navigator.pop don't handle by default the refresh of the screen it pops to.

Fix: I just update the notes_service.dart so that after command.execute, I just redirect to the Home Screen